### PR TITLE
Avoid copying circular objects from the `window` object to the context object after each eval

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var indexOf = require('indexof');
+
 var Object_keys = function (obj) {
     if (Object.keys) return Object.keys(obj)
     else {
@@ -39,10 +41,17 @@ Script.prototype.runInNewContext = function (context) {
         win.execScript('null');
     }
     
+    var winKeys = Object_keys(win);
+
     var res = win.eval(this.code);
     
     forEach(Object_keys(win), function (key) {
-        context[key] = win[key];
+        // Avoid copying circular objects like `top` and `window` by only
+        // updating existing context properties or new properties in the `win`
+        // that was only introduced after the eval.
+        if (key in context || indexOf(winKeys, key) === -1) {
+            context[key] = win[key];
+        }
     });
     
     document.body.removeChild(iframe);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
         "browser",
         "eval"
     ],
+    "dependencies": {
+      "indexof": "0.0.1"
+    },
     "devDependencies" : {
         "tap" : "~0.2.1",
         "browserify" : "1.9.x"

--- a/testling/run.js
+++ b/testling/run.js
@@ -20,3 +20,15 @@ test('vmRunInNewContext', function (t) {
     
     t.end();
 });
+
+test('vmRunInContext', function (t) {
+    t.plan(2);
+
+    var context = vm.createContext({ foo: 1 });
+
+    vm.runInContext('var x = 1', context);
+    t.deepEqual(context, { foo: 1, x: 1 });
+
+    vm.runInContext('var y = 1', context);
+    t.deepEqual(context, { foo: 1, x: 1, y: 1 });
+});


### PR DESCRIPTION
Fixes #4

Added tests. Couldn't run in testling but was able to test in the browser using `tape`.
