### PR TITLE
Only copy ctx properties when `context` is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,9 +109,11 @@ Script.prototype.runInNewContext = function (context) {
     var ctx = Script.createContext(context);
     var res = this.runInContext(ctx);
 
-    forEach(Object_keys(ctx), function (key) {
-        context[key] = ctx[key];
-    });
+    if (context) {
+        forEach(Object_keys(ctx), function (key) {
+            context[key] = ctx[key];
+        });
+    }
 
     return res;
 };


### PR DESCRIPTION
Fixes #12.
