### PR TITLE
Update example-file to use HTTPS and modern jQuery

### DIFF
--- a/example/run/index.html
+++ b/example/run/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="/bundle.js"></script>
   </head>
   <body>


### PR DESCRIPTION
The example file is shipped with the npm-module when installed, and some security software flags the use of jQuery 1.7.1 due it having security vulnerabilities.

Update example to use modern jQuery and HTTPS while we're at it.